### PR TITLE
Update BuildNETCDF.cmake

### DIFF
--- a/cmake-modules/BuildNETCDF.cmake
+++ b/cmake-modules/BuildNETCDF.cmake
@@ -60,7 +60,7 @@ macro(build_netcdf install_prefix staging_prefix)
 
   ExternalProject_Add(NETCDF 
     URL "https://github.com/Unidata/netcdf-c/archive/v4.3.3.1.tar.gz"
-    URL_MD5 "5c9dad3705a3408d27f696e5b31fb88c"
+    URL_MD5 "41fe6758d46cccb1675693d155ee7001"
   SOURCE_DIR NETCDF
   BINARY_DIR NETCDF-build
   PATCH_COMMAND ${PATCH_QUIET}


### PR DESCRIPTION
The MD5 sum for this NetCDF package changed (https://github.com/Unidata/netcdf-c/archive/v4.3.3.1.tar.gz as compared to ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.3.3.1.tar.gz)